### PR TITLE
Add transparency to select arrow button

### DIFF
--- a/src/components/GameSelect.js
+++ b/src/components/GameSelect.js
@@ -78,7 +78,7 @@ const GameSelect = () => {
             justifyContent: "center",
             borderRadius: "50%",
             border: "1.5px solid #000",
-            bg: "#fefefe",
+            bg: "#fefefe66",
           }}
         >
           <FiChevronDown


### PR DESCRIPTION
Same thing as the other one but for the select. Not actually showing the `GameSelect` again yet though